### PR TITLE
feat(cache-page): Adding page caching get, set routes

### DIFF
--- a/src/services/queries/page-cache.ts
+++ b/src/services/queries/page-cache.ts
@@ -1,3 +1,19 @@
-export const getCachedPage = (route: string) => {};
+import { client } from '$services/redis';
 
-export const setCachedPage = (route: string, page: string) => {};
+const cacheRoutes = ['/about', '/privacy', '/auth/signin', '/auth/signup'];
+
+export const getCachedPage = (route: string) => {
+	if (cacheRoutes.includes(route)) {
+		return client.get(`pagecache#${route}`);
+	}
+
+	return null;
+};
+
+export const setCachedPage = (route: string, page: string) => {
+	const options = { EX: 2 };
+
+	if (cacheRoutes.includes(route)) {
+		return client.set(`pagecache#${route}`, page, options);
+	}
+};


### PR DESCRIPTION
# What are changes?
- Adding page caching for routes `['/about', '/privacy', '/auth/signin', '/auth/signup']`
- Set caching expiration